### PR TITLE
Don't check for root

### DIFF
--- a/cmd/torch.js
+++ b/cmd/torch.js
@@ -49,11 +49,6 @@ function die(msg) {
     process.exit(1);
 }
 
-// Should really be geteuid
-function amIRoot() {
-    return process.getuid() === 0;
-}
-
 function pidExists(pid) {
     // jscs:disable disallowKeywords
     try {
@@ -135,10 +130,6 @@ function outputDTraceText(stacks) {
 }
 
 function main() {
-    if (!amIRoot()) {
-        die('Root privileges required.');
-    }
-
     var args = parseArgs(process.argv);
     if (!pidExists(args.pid)) {
         die(util.format('Process %d does not exist.', args.pid));
@@ -168,7 +159,6 @@ if (require.main === module) {
     process.nextTick(main);
 } else {
     module.exports = {
-        amIRoot: amIRoot,
         parseArgs: parseArgs,
         pidExists: pidExists
     };


### PR DESCRIPTION
SystemTap doesn't have to be run as root: here are other options. See the **permissions** section on it's man page: https://sourceware.org/systemtap/man/stap.1.html